### PR TITLE
[TG Mirror] Fixes assembly shells not using power from the wire/button they are attached to. [MDB IGNORE]

### DIFF
--- a/code/modules/wiremod/shell/assembly.dm
+++ b/code/modules/wiremod/shell/assembly.dm
@@ -27,9 +27,9 @@
 	RegisterSignals(src, list(COMSIG_ASSEMBLY_ATTACHED, COMSIG_ASSEMBLY_ADDED_TO_BUTTON, COMSIG_ASSEMBLY_ADDED_TO_PRESSURE_PLATE), PROC_REF(on_attached))
 	RegisterSignals(src, list(COMSIG_ASSEMBLY_DETACHED, COMSIG_ASSEMBLY_REMOVED_FROM_BUTTON, COMSIG_ASSEMBLY_REMOVED_FROM_PRESSURE_PLATE), PROC_REF(on_detached))
 
-/obj/item/assembly/wiremod/proc/on_circuit_attached(source, obj/item/integrated_circuit/circuit)
+/obj/item/assembly/wiremod/proc/on_circuit_attached(datum/component/shell/source)
 	SIGNAL_HANDLER
-	RegisterSignal(circuit, COMSIG_CIRCUIT_PRE_POWER_USAGE, PROC_REF(override_circuit_power_usage))
+	RegisterSignal(source.attached_circuit, COMSIG_CIRCUIT_PRE_POWER_USAGE, PROC_REF(override_circuit_power_usage))
 
 /obj/item/assembly/wiremod/proc/on_circuit_removed(datum/component/shell/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION
Original PR: 91384
-----
## About The Pull Request

How did I miss how `COMSIG_SHELL_ATTACH_CIRCUIT` was handled?

## Why It's Good For The Game

Makes a circuit shell actually do what I claim it does.

Fixes #90786

## Changelog

:cl:
fix: Fixes assembly shells not taking power from machines/mechs/borgs instead of needing a cell when attached to such things. Did you know this was supposed to be a feature, but didn't work for who-knows-how-long?
/:cl:
