### PR TITLE
[TG Mirror] PDA painters no longer break the visuals of any PDAs painted with them [MDB IGNORE]

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -327,12 +327,12 @@
 					pda_path = path
 					break
 
-			if(initial(pda_path.greyscale_config) && initial(pda_path.greyscale_colors))
-				stored_pda.set_greyscale(initial(pda_path.greyscale_colors), initial(pda_path.greyscale_config))
+			if(pda_path::greyscale_config && pda_path::greyscale_colors)
+				stored_pda.set_greyscale(pda_path::greyscale_colors, pda_path::greyscale_config)
 			else
-				stored_pda.icon = initial(pda_path.icon)
-			stored_pda.icon_state = initial(pda_path.icon_state)
-			stored_pda.desc = initial(pda_path.desc)
+				stored_pda.icon = pda_path::icon
+			stored_pda.icon_state = pda_path::post_init_icon_state || pda_path::icon_state
+			stored_pda.desc = pda_path::desc
 
 			return TRUE
 		if("reset_pda")


### PR DESCRIPTION
Original PR: 91398
-----

## About The Pull Request

It seems #90940 introduced some wonky `icon_state` trickery, where the initial `icon_state` isn't actually one we want, but PDA painters were still setting it to that.
This instead makes it use `pda_path::post_init_icon_state` and fall back to `pda_path::icon_state` doesn't exist like the mentioned pr did for other such things.
## Why It's Good For The Game

Fixes #91396.
## Changelog
:cl:
fix: PDA painters no longer break the visuals of any PDAs painted with them.
/:cl:
