### PR TITLE
[TG Mirror] Fixes revolver reloading, again [MDB IGNORE]

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -44,7 +44,7 @@
 
 	for(var/i in 1 to stored_ammo.len)
 		var/obj/item/ammo_casing/bullet = stored_ammo[i]
-		if (istype(bullet) && bullet.loaded_projectile)
+		if (!istype(bullet) || bullet.loaded_projectile)
 			continue
 		// found a spent ammo
 		stored_ammo[i] = R

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -21,7 +21,6 @@
 	if(.)
 		last_fire = world.time
 
-
 /obj/item/gun/ballistic/revolver/chamber_round(spin_cylinder = TRUE, replace_new_round)
 	if(!magazine) //if it mag was qdel'd somehow.
 		CRASH("revolver tried to chamber a round without a magazine!")
@@ -57,7 +56,6 @@
 		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound)
 		if(play_click)
 			playsound(src, 'sound/items/weapons/gun/general/ballistic_click.ogg', fire_sound_volume, vary_fire_sound, frequency = click_frequency_to_use)
-
 
 /obj/item/gun/ballistic/revolver/verb/spin()
 	set name = "Spin Chamber"


### PR DESCRIPTION
Original PR: 91414
-----

## About The Pull Request

Closes #91110, broke due to lazyloaded bullets being considered empty

This needs a unit test, maybe will write one later in a separate PR

## Changelog
:cl:
fix: Fixed revolver reloading, again
/:cl:
