### PR TITLE
[TG Mirror] Implement some more stuff for `/datum/client_interface` [MDB IGNORE]

### DIFF
--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -3,6 +3,9 @@
 	/// Player preferences datum for the client
 	var/datum/preferences/prefs
 
+	/// These persist between logins/logouts during the same round.
+	var/datum/persistent_client/persistent_client
+
 	/// The view of the client, similar to /client/var/view.
 	var/view = "15x15"
 
@@ -25,26 +28,50 @@
 	var/ban_cache = null
 	var/ban_cache_start = 0
 
+	// Mock BYOND version will always be the same as the server's BYOND version.
+	var/byond_version
+	var/byond_build
+
 	/// client prefs
 	var/fps
 	var/hotkeys
 	var/tgui_say
 	var/typing_indicators
+	var/window_scaling
+
+	var/fully_created = FALSE
+
+	var/static/mock_client_uid = 0
 
 /datum/client_interface/New()
 	..()
-	var/static/mock_client_uid = 0
-	mock_client_uid++
 
-	src.key = "[key]_[mock_client_uid]"
+	byond_version = world.byond_version
+	byond_build = world.byond_build
+
+	src.key = "[key]_[mock_client_uid++]"
 	ckey = ckey(key)
 
 #ifdef UNIT_TESTS // otherwise this shit can leak into production servers which is drather bad
 	GLOB.directory[ckey] = src
+
+	if(GLOB.persistent_clients_by_ckey[ckey])
+		persistent_client = GLOB.persistent_clients_by_ckey[ckey]
+		persistent_client.byond_build = byond_build
+		persistent_client.byond_version = byond_version
+	else
+		persistent_client = new(ckey)
+		persistent_client.byond_build = byond_build
+		persistent_client.byond_version = byond_version
 #endif
+
+	fully_created = TRUE
 
 /datum/client_interface/Destroy(force)
 	GLOB.directory -= ckey
+	if(persistent_client?.client == src)
+		persistent_client.client = null
+	persistent_client = null
 	return ..()
 
 /datum/client_interface/proc/IsByondMember()


### PR DESCRIPTION
Original PR: 91403
-----

## About The Pull Request

this adds the `persistent_client`, `fully_created`, `window_scaling`, `byond_version`, and `byond_build` vars to `/datum/client_interface`, to closer match the interface.

- `byond_version` and `byond_build` will always be set to `world.byond_version` and `world.byond_build`
- persistent clients are only initialized for mock clients during unit tests.
- i also slightly changed the `mock_client_uid` var so it's used in the same way as mobs use `next_mob_id`

## Why It's Good For The Game

fixes annoying CI failures, and makes the mock interface a bit more useful.

## Changelog

no player-facing changes
