### PR TITLE
[TG Mirror] Oxygen tanks use progress bar [MDB IGNORE]

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -21,7 +21,7 @@
 	///Where to draw the progress bar above the icon
 	var/offset_y
 
-/datum/progressbar/New(mob/User, goal_number, atom/target)
+/datum/progressbar/New(mob/User, goal_number, atom/target, starting_amount)
 	. = ..()
 	if (!istype(target))
 		stack_trace("Invalid target [target] passed in")
@@ -60,6 +60,8 @@
 	RegisterSignal(user, COMSIG_MOB_LOGOUT, PROC_REF(clean_user_client))
 	RegisterSignal(user, COMSIG_MOB_LOGIN, PROC_REF(on_user_login))
 
+	if(starting_amount)
+		update(starting_amount)
 
 /datum/progressbar/Destroy()
 	if(user)

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -57,6 +57,8 @@
 	var/list/reaction_info
 	/// Mob that is currently breathing from the tank.
 	var/mob/living/carbon/breathing_mob = null
+	///Progress bar showing how much volume is in the tank when equipped.
+	var/datum/progressbar/volume_bar
 	/// Attached assembly, can either detonate the tank or release its contents when receiving a signal
 	var/obj/item/assembly_holder/tank_assembly
 	/// Whether or not it will try to explode when it receives a signal
@@ -89,19 +91,14 @@
 /obj/item/tank/proc/after_internals_opened(mob/living/carbon/carbon_target)
 	breathing_mob = carbon_target
 	playsound(loc, 'sound/items/internals/internals_on.ogg', 15, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	RegisterSignal(carbon_target, COMSIG_MOB_GET_STATUS_TAB_ITEMS, PROC_REF(get_status_tab_item))
+	var/pressure_on_open = air_contents.return_pressure() //we start off "full" when we toggle, and count down from there.
+	volume_bar = new(carbon_target, pressure_on_open, src, pressure_on_open)
 
 /// Called by carbons after they disconnect the tank from their breathing apparatus.
 /obj/item/tank/proc/after_internals_closed(mob/living/carbon/carbon_target)
 	breathing_mob = null
 	playsound(loc, 'sound/items/internals/internals_off.ogg', 15, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	UnregisterSignal(carbon_target, COMSIG_MOB_GET_STATUS_TAB_ITEMS)
-
-/obj/item/tank/proc/get_status_tab_item(mob/living/source, list/items)
-	SIGNAL_HANDLER
-	items += "Internal Atmosphere Info: [name]"
-	items += "Tank Pressure: [air_contents.return_pressure()] kPa"
-	items += "Distribution Pressure: [distribute_pressure] kPa"
+	QDEL_NULL(volume_bar)
 
 /// Attempts to toggle the mob's internals on or off using this tank. Returns TRUE if successful.
 /obj/item/tank/proc/toggle_internals(mob/living/carbon/mob_target)
@@ -139,6 +136,7 @@
 	STOP_PROCESSING(SSobj, src)
 	air_contents = null
 	QDEL_NULL(tank_assembly)
+	QDEL_NULL(volume_bar)
 	return ..()
 
 /obj/item/tank/update_overlays()
@@ -324,6 +322,8 @@
 /obj/item/tank/process(seconds_per_tick)
 	if(!air_contents)
 		return
+	if(!QDELETED(volume_bar))
+		volume_bar.update(air_contents.return_pressure())
 
 	//Allow for reactions
 	excited = (excited | air_contents.react(src))


### PR DESCRIPTION
Original PR: 91387
-----
## About The Pull Request

Tanks while used as internals gives a progress bar to show how full they are, starting from the pressure when first starting to get used, when we expect the player to know how much is in the tank, and ticking down as it gets used. Alternative to this could be using the initial pressure, but then it would remain at 100% for quite a while when you put more than it starts off with.

This replaces the stat panel entry for them, this is a part of https://hackmd.io/443_dE5lRWeEAp9bjGcKYw

![image](https://github.com/user-attachments/assets/a0d5c3db-fbbd-4598-8f02-53f24c81524d)

## Why It's Good For The Game

Adds a visual indicator to tell people how much air they've used since toggling the tank's internals which is much better than the previous' random numbers in stat panel.

## Changelog

:cl:
qol: internal tanks gives a progress bar when you toggle them, allowing you to see how much you've consumed so far.
/:cl: