### PR TITLE
[TG Mirror] Returns the title bar [MDB IGNORE]

### DIFF
--- a/code/modules/client/preferences/screen.dm
+++ b/code/modules/client/preferences/screen.dm
@@ -13,4 +13,7 @@
 	savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/toggle/fullscreen_mode/apply_to_client(client/client, value)
+	//let's not apply unless the client is fully logged in, therefore manually triggering it.
+	if(!client.fully_created)
+		return
 	client.set_fullscreen()


### PR DESCRIPTION
Original PR: 91402
-----
## About The Pull Request

It breaks by setting ``is-fullscreen`` to false so we need to basically not call set_fullscreen ever as it will permanently remove it from the client. I can't figure out why this happens, but setting ``is-fullscreen`` to any value permanently removes ``menu`` from mainwindow, which is what this subtitle bar thing uses.

## Why It's Good For The Game

I don't like the title bar and i want it gone but this is a bug fix.

## Changelog

:cl:
fix: The title bar is back for non-fullscreen users.
/:cl: