### PR TITLE
[TG Mirror] Fix some DB issues and lag [MDB IGNORE]

### DIFF
--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -2,19 +2,29 @@ Any time you make a change to the schema files, remember to increment the databa
 
 Make sure to also update `DB_MAJOR_VERSION` and `DB_MINOR_VERSION`, which can be found in `code/__DEFINES/subsystem.dm`.
 
-The latest database version is 5.31; The query to update the schema revision table is:
+The latest database version is 5.32; The query to update the schema revision table is:
 
 ```sql
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 31);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 32);
 ```
 
 or
 
 ```sql
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 31);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 32);
 ```
 
 In any query remember to add a prefix to the table names if you use one.
+
+---
+
+Version 5.32, 31 May 2025, by TealSeer
+Change column name of `manifest` table because `character` is a reserved word.
+
+```sql
+ALTER TABLE `manifest`
+	RENAME COLUMN `character` TO `character_name`;
+```
 
 ---
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -306,7 +306,7 @@ CREATE TABLE `manifest` (
   `server_port` smallint(5) NOT NULL,
   `round_id` int(11) NOT NULL,
   `ckey` text NOT NULL,
-  `character` text NOT NULL,
+  `character_name` text NOT NULL,
   `job` text NOT NULL,
   `special` text DEFAULT NULL,
   `latejoin` tinyint(1) NOT NULL DEFAULT 0,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -305,7 +305,7 @@ CREATE TABLE `SS13_manifest` (
   `server_port` smallint(5) NOT NULL,
   `round_id` int(11) NOT NULL,
   `ckey` text NOT NULL,
-  `character` text NOT NULL,
+  `character_name` text NOT NULL,
   `job` text NOT NULL,
   `special` text DEFAULT NULL,
   `latejoin` tinyint(1) NOT NULL DEFAULT 0,

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 31
+#define DB_MINOR_VERSION 32
 
 
 //! ## Timing subsystem

--- a/code/__HELPERS/logging/manifest.dm
+++ b/code/__HELPERS/logging/manifest.dm
@@ -4,4 +4,6 @@
 	logger.Log(LOG_CATEGORY_MANIFEST, message, list(
 		"mind" = mind, "body" = body, "latejoin" = latejoin
 	))
-	SSblackbox.ReportManifest(ckey, body.real_name, mind.assigned_role.title, mind.special_role, latejoin)
+	// Roundstart happens with SSblackbox.ReportRoundstartManifest
+	if(latejoin)
+		SSblackbox.ReportManifest(ckey, body.real_name, mind.assigned_role.title, mind.special_role, latejoin)

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -416,13 +416,30 @@ Versioning
 		query_report_citation.Execute(async = TRUE)
 		qdel(query_report_citation)
 
+/datum/controller/subsystem/blackbox/proc/ReportRoundstartManifest(list/characters)
+	var/list/query_rows = list()
+	var/list/special_columns = list("server_ip" = "INET_ATON(?)")
+	for(var/mob_ckey as anything in characters)
+		var/mob/living/new_character = characters[mob_ckey]
+		query_rows += list(list(
+			"server_ip" = world.internet_address || 0,
+			"server_port" = world.port,
+			"round_id" = GLOB.round_id,
+			"ckey" = mob_ckey,
+			"character_name" = new_character.real_name,
+			"job" = new_character.mind?.assigned_role?.title,
+			"special" = new_character.mind?.special_role,
+			"latejoin" = 0,
+		))
+	SSdbcore.MassInsert(format_table_name("manifest"), query_rows, special_columns = special_columns)
+
 /datum/controller/subsystem/blackbox/proc/ReportManifest(ckey, character, job, special, latejoin)
 	var/datum/db_query/query_report_manifest = SSdbcore.NewQuery({"INSERT INTO [format_table_name("manifest")]
 	(server_ip,
 	server_port,
 	round_id,
 	ckey,
-	character,
+	character_name,
 	job,
 	special,
 	latejoin) VALUES (
@@ -430,16 +447,16 @@ Versioning
 	:port,
 	:round_id,
 	:ckey,
-	:character,
+	:character_name,
 	:job,
 	:special,
 	:latejoin)
 	"}, list(
-		"server_ip" = world.internet_address || "0",
-		"port" = "[world.port]",
+		"server_ip" = world.internet_address || 0,
+		"port" = world.port,
 		"round_id" = GLOB.round_id,
 		"ckey" = ckey,
-		"character" = character,
+		"character_name" = character,
 		"job" = job,
 		"special" = special,
 		"latejoin" = latejoin

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -11,12 +11,17 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 
 /// Builds the list of crew records for all crew members.
 /datum/manifest/proc/build()
+	// List of mobs we want to mass insert into the manifest table at round start
+	var/list/players_to_log = list()
 	for(var/mob/dead/new_player/readied_player as anything in GLOB.new_player_list)
 		if(readied_player.new_character)
 			log_manifest(readied_player.ckey, readied_player.new_character.mind, readied_player.new_character)
+			players_to_log[readied_player.ckey] = readied_player.new_character
 		if(ishuman(readied_player.new_character))
 			inject(readied_player.new_character)
 		CHECK_TICK
+	if(length(players_to_log))
+		SSblackbox.ReportRoundstartManifest(players_to_log)
 
 /// Gets the current manifest.
 /datum/manifest/proc/get_manifest()


### PR DESCRIPTION
Original PR: 91420
-----
## About The Pull Request

- ~~The DB schema version define was set to 5.30, the changelog readme said the latest was 5.28, and the sample insert query in the readme said it was 5.31~~ (fixed in #91127) Changes the define and readme to 5.32
- Add new entry in readme to rename `character` column in `manifest` table to `character_name`, because `character` is a reserved word in SQL and every insert query is failing
- Changed the initial roundstart manifest queries from number_of_players_readied_up individual insert queries to one mass insert because I suspect this is add several extra seconds to the start time

## Why It's Good For The Game
fix yes :)
## Changelog
:cl:
server: increment DB schema version to 5.32
server: changed column name in manifest table from character to character_name because the former is a reserved word
fix: changed round start manifest DB queries from dozens of individual inserts to one mass insert
fix: hopefully fixed some lag on round start
/:cl:
