### PR TITLE
[TG Mirror] Fixes speed potions behaving super inconsistently on magboots, duffelbags and laptops [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/storage/dufflebags.dm
+++ b/code/game/objects/items/storage/dufflebags.dm
@@ -23,6 +23,7 @@
 /obj/item/storage/backpack/duffelbag/Initialize(mapload)
 	. = ..()
 	set_zipper(TRUE)
+	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, PROC_REF(on_speed_potioned))
 
 /obj/item/storage/backpack/duffelbag/update_desc(updates)
 	. = ..()
@@ -87,17 +88,23 @@
 	zipped_up = new_zip
 	SEND_SIGNAL(src, COMSIG_DUFFEL_ZIP_CHANGE, new_zip)
 	if(zipped_up)
-		slowdown = initial(slowdown)
+		slowdown -= zip_slowdown
 		atom_storage.set_locked(STORAGE_SOFT_LOCKED)
 		atom_storage.display_contents = FALSE
 	else
-		slowdown = zip_slowdown
+		slowdown += zip_slowdown
 		atom_storage.set_locked(STORAGE_NOT_LOCKED)
 		atom_storage.display_contents = TRUE
 
 	if(isliving(loc))
 		var/mob/living/wearer = loc
 		wearer.update_equipment_speed_mods()
+
+/// Signal handler for [COMSIG_SPEED_POTION_APPLIED]. Speed potion removes the unzipped slowdown
+/obj/item/storage/backpack/duffelbag/proc/on_speed_potioned(datum/source)
+	SIGNAL_HANDLER
+	// Don't need to touch the actual slowdown here, since the speed potion does it for us
+	zip_slowdown = 0
 
 /obj/item/storage/backpack/duffelbag/cursed
 	name = "living duffel bag"

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -69,7 +69,7 @@
 		else if(magpulse_fishing_modifier != fishing_modifier)
 			qdel(GetComponent(/datum/component/adjust_fishing_difficulty))
 		detach_clothing_traits(active_traits)
-		slowdown = max(initial(slowdown), slowdown - slowdown_active) // Just in case, for speed pot shenanigans
+		slowdown -= slowdown_active
 
 	update_appearance()
 	balloon_alert(user, "mag-pulse [magpulse ? "enabled" : "disabled"]")
@@ -89,7 +89,7 @@
 	desc = "Advanced magnetic boots that have a lighter magnetic pull, placing less burden on the wearer."
 	icon_state = "advmag0"
 	base_icon_state = "advmag"
-	slowdown_active = SHOES_SLOWDOWN // ZERO active slowdown
+	slowdown_active = 0 // ZERO active slowdown
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	magpulse_fishing_modifier = 3
 	fishing_modifier = 0

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -910,11 +910,11 @@
 	if(!isobj(interacting_with))
 		to_chat(user, span_warning("The potion can only be used on objects!"))
 		return ITEM_INTERACT_BLOCKING
+
 	if(HAS_TRAIT(interacting_with, TRAIT_SPEED_POTIONED))
 		to_chat(user, span_warning("[interacting_with] can't be made any faster!"))
 		return ITEM_INTERACT_BLOCKING
-	if(SEND_SIGNAL(interacting_with, COMSIG_SPEED_POTION_APPLIED, src, user) & SPEED_POTION_STOP)
-		return ITEM_INTERACT_SUCCESS
+
 	if(isitem(interacting_with))
 		var/obj/item/apply_to = interacting_with
 		if(apply_to.slowdown <= 0 || (apply_to.item_flags & IMMUTABLE_SLOW) || HAS_TRAIT(apply_to, TRAIT_NO_SPEED_POTION))
@@ -922,6 +922,12 @@
 				return NONE // lets us put the potion in the bag
 			to_chat(user, span_warning("[apply_to] can't be made any faster!"))
 			return ITEM_INTERACT_BLOCKING
+
+	if(SEND_SIGNAL(interacting_with, COMSIG_SPEED_POTION_APPLIED, src, user) & SPEED_POTION_STOP)
+		return ITEM_INTERACT_SUCCESS
+
+	if(isitem(interacting_with))
+		var/obj/item/apply_to = interacting_with
 		apply_to.slowdown = 0
 
 	to_chat(user, span_notice("You slather the red gunk over the [interacting_with], making it faster."))


### PR DESCRIPTION
Original PR: 91415
-----

## About The Pull Request

The issue was threefold, first speed potions sent the comsig before actually applying which could be abused to make items not have a slowdown without spending it or coloring them by using it on them in a state when they don't have a slowdown (i.e. disabled magboots). Magboots ``initial()``'d their slowdown which could break them if they somehow got it negative, but I believe that didn't happen in actual gameplay. And I've made duffelbags and laptops have their open slowdown set to 0 similarly to magboots when a speed potion is applied to them. Last one may be a balance change, depending on the original intent, but I'm going off their pre-rework behavior here (and it generally feels weird to be the case when they get unslowdowned and then it gets reapplied when you close and open them)

- Closes #91381

## Changelog
:cl:
fix: Fixed speed potions behaving super inconsistently on magboots, duffelbags and laptops
/:cl:
