### PR TITLE
[TG Mirror] Create object panel search function works again [MDB IGNORE]

### DIFF
--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -9,7 +9,7 @@
 		var/objectjs = null
 		objectjs = jointext(typesof(/obj), ";")
 		create_object_html = file2text('html/create_object.html')
-		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
+		create_object_html = replacetext(create_object_html, "null; /* object types */", "\"[objectjs]\";")
 
 	user << browse(create_panel_helper(create_object_html), "window=create_object;size=425x475")
 
@@ -26,7 +26,7 @@
 		var/objectjs = jointext(typesof(path), ";")
 		html_form = file2text('html/create_object.html')
 		html_form = replacetext(html_form, "Create Object", "Create [path]")
-		html_form = replacetext(html_form, "null /* object types */", "\"[objectjs]\"")
+		html_form = replacetext(html_form, "null; /* object types */", "\"[objectjs]\";")
 		create_object_forms[path] = html_form
 
 	user << browse(create_panel_helper(html_form), "window=qco[path];size=425x475")


### PR DESCRIPTION
Original PR: 91431
-----
## About The Pull Request
Broken by #91379 all because a semicolon got misplaced

Before
![Screenshot (463)](https://github.com/user-attachments/assets/7de12f0e-8da1-4ccf-9450-384cd66e6cb7)

After
![Screenshot (464)](https://github.com/user-attachments/assets/6684b6a5-aa1b-4fe2-9e26-dc43b8dcba10)

And the code wasn't updated to check for this change
https://github.com/tgstation/tgstation/blob/58cd0099d9ddf0afbe710469ae39dd6ff5c882fc/code/modules/admin/create_object.dm#L12
https://github.com/tgstation/tgstation/blob/58cd0099d9ddf0afbe710469ae39dd6ff5c882fc/code/modules/admin/create_object.dm#L29

Well now it does

## Changelog
:cl:
fix: create object panel for game admins works again
/:cl:

