### PR TITLE
[TG Mirror] Xenobiology is slightly more convenient and slightly less text spammy [MDB IGNORE]

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -126,14 +126,14 @@
 		xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
 		return
 
-	if(istype(used_item, /obj/item/storage/bag))
-		var/obj/item/storage/storage_bag = used_item
+	if(istype(used_item, /obj/item/storage/bag) || istype(used_item, /obj/item/storage/box/monkeycubes))
+		var/obj/item/storage/storage_container = used_item
 		var/loaded = FALSE
-		for(var/obj/item_in_bag in storage_bag.contents)
-			if(istype(item_in_bag, /obj/item/food/monkeycube))
+		for(var/obj/storage_item in storage_container.contents)
+			if(istype(storage_item, /obj/item/food/monkeycube))
 				loaded = TRUE
 				monkeys++
-				qdel(item_in_bag)
+				qdel(storage_item)
 		if(loaded)
 			to_chat(user, span_notice("You fill [src] with the monkey cubes stored in [used_item]. [src] now has [monkeys] monkey cubes stored."))
 			xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
@@ -182,10 +182,14 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 ///Places every slime in storage on target turf
 /obj/machinery/computer/camera_advanced/xenobio/proc/slime_place(turf/open/target_turf)
 	spit_out(stored_slimes, target_turf)
+	if(stored_slimes.len <= 0)
+		return
+	if(stored_slimes.len == 1)
+		target_turf.visible_message(span_notice("The slime is spat out!"))
+	else
+		target_turf.visible_message(span_notice("[stored_slimes.len] slimes are spat out!"))
 	for(var/mob/living/basic/slime/stored_slime in stored_slimes)
 		stored_slime.forceMove(target_turf)
-		stored_slime.visible_message(span_notice("[stored_slime] is spat out!"))
-		stored_slimes -= stored_slime
 		REMOVE_TRAIT(stored_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
 		stored_slime.handle_slime_stasis(0)
 	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
@@ -202,7 +206,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		return FALSE
 	if(target_slime.buckled)
 		target_slime.stop_feeding(silent = TRUE)
-	target_slime.visible_message(span_notice("[target_slime] gets sucked up!"))
+	target_slime.visible_message(span_notice("The slime gets sucked up!"))
 	suck_up(target_slime)
 	target_slime.forceMove(src)
 	stored_slimes += target_slime
@@ -236,7 +240,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		return
 
 	suck_up(target_mob)
-	target_mob.visible_message(span_notice("[target_mob] shoots up as [p_theyre()] reclaimed for recycling!"))
+	target_mob.visible_message(span_notice("The monkey shoots up as [p_theyre()] reclaimed for recycling!"))
 	connected_recycler.use_energy(500 JOULES)
 	monkeys += connected_recycler.cube_production
 	monkeys = round(monkeys, 0.1) //Prevents rounding errors


### PR DESCRIPTION
Original PR: 91065
-----
## About The Pull Request

- Monkey cube boxes can now insert their items straight into xenobio consoles
- Sucking/placing slimes/monkeys no longer says mob ID numbers; this means that the notification messages now get counted as duplicates and filtered for spam, instead of being seen as unique posts
- Placing multiple slimes all at once will just say "[x] slime(s) warp in" instead of saying "the [color] slime warps in" for each of the slimes in storage

## Why It's Good For The Game

Convenience.
## Changelog
:cl:
qol: monkey cube boxes can now be inserted straight into the xenobiology console
qol: placing/sucking slimes/monkeys is slightly less text spammy
/:cl:
