### PR TITLE
[TG Mirror] Changeling Void Adaption no longer provides full BZ/N2O/etc immunity [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/changeling/powers/void_adaption.dm
+++ b/code/modules/antagonists/changeling/powers/void_adaption.dm
@@ -2,13 +2,13 @@
 	name = "Void Adaption"
 	desc = "We prepare our cells to resist the hostile environment outside of the station. We may freely travel wherever we wish."
 	helptext = "This ability is passive, and will automatically protect you in situations of extreme cold or vacuum, \
-		as well as removing your need to breathe. While it is actively protecting you from temperature or pressure \
-		it reduces your chemical regeneration rate."
+		as well as removing your need to breathe oxygen, although you will still be affected by hazardous gases. \
+		While it is actively protecting you from temperature or pressure it reduces your chemical regeneration rate."
 	owner_has_control = FALSE
 	dna_cost = 2
 
 	/// Traits we apply to become immune to the environment
-	var/static/list/gain_traits = list(TRAIT_NOBREATH, TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE, TRAIT_SNOWSTORM_IMMUNE)
+	var/static/list/gain_traits = list(TRAIT_SPACEBREATHING, TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE, TRAIT_SNOWSTORM_IMMUNE)
 	/// How much we slow chemical regeneration while active, in chems per second
 	var/recharge_slowdown = 0.25
 	/// Are we currently protecting our user?


### PR DESCRIPTION
Original PR: 91412
-----

## About The Pull Request

This replaces `TRAIT_NOBREATH` with `TRAIT_SPACEBREATHING` in void adaptation, and updates the description to reflect such.

This means while they still do breathe, they won't take damage from / notice a lack of oxygen... but they can still be affected by, say, N2O or BZ.

## Why It's Good For The Game

a passive, undetectable counter to the main counter for lings (BZ) is kind of shit, tbh.

they should have to use actual internals if they don't wanna breathe in funny gases.

## Changelog
:cl:
balance: Changeling Void Adaptation no longer fully negates their breathing - instead, it removes their NEED to breathe oxygen, but they will still breathe, meaning they'll still be affected by gases such as N2O and BZ.
/:cl:
