### PR TITLE
[TG Mirror] Healium crystals actually fix air [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -37,12 +37,12 @@
 
 	update_mob()
 	playsound(src, 'sound/effects/spray2.ogg', 100, TRUE)
-	var/list/connected_turfs = detect_room(origin = get_turf(src), max_size = fix_range)
+	var/list/turf_list = RANGE_TURFS(fix_range, src)
 	var/datum/gas_mixture/base_mix = SSair.parse_gas_string(OPENTURF_DEFAULT_ATMOS)
-	for(var/turf/open/turf_fix in connected_turfs)
+	for(var/turf/open/turf_fix in turf_list)
 		if(turf_fix.blocks_air)
 			continue
-		turf_fix.assume_air(base_mix)
+		turf_fix.copy_air(base_mix.copy())
 	qdel(src)
 
 /obj/item/grenade/gas_crystal/proto_nitrate_crystal


### PR DESCRIPTION
Original PR: 91449
-----

## About The Pull Request
Fixes healium crystals not fixing air.
## Why It's Good For The Game
So it turns out `detect_room` doesn't actually work as you think it would.
During my testing, it only gave a list of 8 turfs, even in a whole room.
This means that the radius of 7 actually just meant +7 turfs instead of +7 AOE

I've also swapped out `assume_air` for `copy_air` instead. Because the first proc would just fill the room with air that is too cold/hot based on what it was before.
## Changelog
:cl:
fix: Healium crystals properly work in a 7 range AOE
/:cl:
