### PR TITLE
[TG Mirror] Balloon alerts don't balloon alert for non-runechat users [MDB IGNORE]

### DIFF
--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -44,6 +44,10 @@
 	if (isnull(viewer_client))
 		return
 
+	if(!runechat_prefs_check(viewer, EMOTE_MESSAGE))
+		to_chat(viewer, span_emote("[icon2html(src, viewer)] [src.name]: [text]"))
+		return
+
 	var/image/balloon_alert = image(loc = isturf(src) ? src : get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
 	SET_PLANE_EXPLICIT(balloon_alert, BALLOON_CHAT_PLANE, src)
 	balloon_alert.alpha = 0


### PR DESCRIPTION
Original PR: 91441
-----
## About The Pull Request

Balloon alerts now send message to chat for non runechat users.

![image](https://github.com/user-attachments/assets/76cf9cf1-f5a1-41f5-8444-9daccab4368d)

## Why It's Good For The Game

Opens settings
Turns runechat off
Gets balloon alert
Runechat

## Changelog

:cl:
fix: Users with runechat disabled now get their balloon alerts in chat instead.
/:cl: