### PR TITLE
[TG Mirror] Fixes monkey offsets [MDB IGNORE]

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -225,6 +225,19 @@
 	is_dimorphic = FALSE
 	head_flags = HEAD_LIPS|HEAD_DEBRAIN
 
+/obj/item/bodypart/head/monkey/Initialize(mapload)
+	worn_head_offset = new(
+		attached_part = src,
+		feature_key = OFFSET_HEAD,
+		offset_y = list("south" = 1),
+	)
+	worn_glasses_offset = new(
+		attached_part = src,
+		feature_key = OFFSET_GLASSES,
+		offset_y = list("south" = 1),
+	)
+	return ..()
+
 /obj/item/bodypart/head/alien
 	icon = 'icons/mob/human/species/alien/bodyparts.dmi'
 	icon_static = 'icons/mob/human/species/alien/bodyparts.dmi'

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -94,6 +94,14 @@
 	acceptable_bodyshape = BODYSHAPE_MONKEY
 	dmg_overlay_type = SPECIES_MONKEY
 
+/obj/item/bodypart/chest/monkey/Initialize(mapload)
+	worn_neck_offset = new(
+		attached_part = src,
+		feature_key = OFFSET_NECK,
+		offset_y = list("south" = 1),
+	)
+	return ..()
+
 /obj/item/bodypart/chest/alien
 	icon = 'icons/mob/human/species/alien/bodyparts.dmi'
 	icon_static = 'icons/mob/human/species/alien/bodyparts.dmi'


### PR DESCRIPTION
Original PR: 91442
-----
## About The Pull Request

I noticed this a long time ago when working with monkeys on Monke but completely forgot to bring it upstream.

Fixes monkeys' glasses, hats & scarves

Damn
![image](https://github.com/user-attachments/assets/1a7f5fa7-d676-4dfa-a9e5-702b012b975f)

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/91357

## Changelog

:cl:
fix: Scarves, hats and glasses now fit monkeys better.
/:cl: