### PR TITLE
[TG Mirror] I'm sure why these are snowflaked to early return, so now they're not (removes ancient code cruft) [MDB IGNORE]

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -12,11 +12,6 @@
 /obj/effect/attackby(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
 	if(SEND_SIGNAL(weapon, COMSIG_ITEM_ATTACK_EFFECT, src, user, modifiers, attack_modifiers) & COMPONENT_NO_AFTERATTACK)
 		return TRUE
-
-	// I'm not sure why these are snowflaked to early return but they are
-	if(istype(weapon, /obj/item/mop) || istype(weapon, /obj/item/soap))
-		return
-
 	return ..()
 
 /obj/effect/attack_generic(mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)


### PR DESCRIPTION
Original PR: 91482
-----
## About The Pull Request

Alternative caption: I need one overly dramatic pr per month to survive.

So we have this very funny comment here:
https://github.com/tgstation/tgstation/blob/31932bd679c88ac2d6099c62cfb0bb0b1c2afa46/code/game/objects/effects/effects.dm#L12-L20
And they are! Yeah, okay.

...

Okay but.
Why?
Like c'mon we gotta know why, right?
Like that's why we're here, right?
To know why, right?
To find unexplainable code segments and spend an extended amount of time diving through git blame tracking them through the different files they've been moved between over the years to finally work out once and for all why this random fucked up little segment of code has been proxied up and up through its years in the codebase?

...

No?

...

Just me?
<sup><sub>Well and Melbert was there too I suppose so like that's cool he's a cool guy :+1: but like I gotta stick to the bit I've been building up to like y'all're cool too :+1: and you totally like get it right like you totally get it like so like -</sub></sup>
...
<sub>coughs</sub>

Anyhow! So! Let's get to the point.
This commit. This commit right here? https://github.com/tgstation/tgstation/commit/2190408f0f646a713fc1f4da6880b15e03991a2b
The one that initially added this code?
https://github.com/tgstation/tgstation/blob/2190408f0f646a713fc1f4da6880b15e03991a2b/code/game/objects/items/weapons/mops_cleaners.dm#L191-L194
This explains it all:
> (...), and got rid of the "X attacks the blood with the mop!" message.

All of it- oh wait so it hasn't mattered for like years upon years now.

oh yeah cool time to obliterate it from orbit let's go let's fucking go let's FUCKING **GO** :+1:
## Why It's Good For The Game

I'm not sure why these are snowflaked to early return but they are
## Changelog
No player-facing changes.
