### PR TITLE
[TG Mirror] Adds a wall dent mapping helper [MDB IGNORE]

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1496,3 +1496,29 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_atoms_ontop)
 	name = "Basic mob immune to getting wet flag helper"
 	icon_state = "basic_mob_immune_to_getting_wet"
 	flag_to_give = IMMUNE_TO_GETTING_WET
+
+/obj/effect/mapping_helpers/wall_dent
+	name = "bullet impact dent"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "bullet_hole"
+	/// Dent type to spawn
+	var/dent_type = WALL_DENT_SHOT
+
+/obj/effect/mapping_helpers/wall_dent/Initialize(mapload)
+	. = ..()
+	if(!mapload)
+		log_mapping("[src] spawned outside of mapload!")
+		return
+
+	var/turf/closed/wall/our_turf = get_turf(src) // In case a locker ate us or something
+	if (!istype(our_turf))
+		log_mapping("[src] placed on a non-wall turf!")
+		return
+
+	our_turf.add_dent(dent_type, pixel_x + pixel_w - ICON_SIZE_X / 2, pixel_y + pixel_z - ICON_SIZE_Y / 2)
+	return INITIALIZE_HINT_QDEL
+
+/obj/effect/mapping_helpers/wall_dent/impact
+	name = "blunt impact dent"
+	icon_state = "impact1"
+	dent_type = WALL_DENT_HIT


### PR DESCRIPTION
Original PR: 91484
-----

## About The Pull Request
Adds two new helpers which add bullet and blunt impact dents upon mapload respectively

## Why It's Good For The Game

Mappers want this

## Changelog

Not player facing
