### PR TITLE
[TG Mirror] Makes your mother turn around to face her disappointment of a child [MDB IGNORE]

### DIFF
--- a/code/modules/hallucination/mother.dm
+++ b/code/modules/hallucination/mother.dm
@@ -80,7 +80,7 @@
 	var/mob/living/hallucinator = parent.hallucinator
 	if (ishuman(hallucinator))
 		var/mob/living/carbon/dna_haver = hallucinator
-		image_icon = getFlatIcon(get_dynamic_human_appearance(/datum/outfit/yourmother, dna_haver.dna.species.type))
+		image_icon = image(get_dynamic_human_appearance(/datum/outfit/yourmother, dna_haver.dna.species.type))
 		return ..()
 
 	if (istype(hallucinator, /mob/living/basic/pet/dog/corgi/ian))


### PR DESCRIPTION
Original PR: 91478
-----
## About The Pull Request

Doesn't get a flat icon of your mother, using an image instead thus making it that she correctly turns around when you try to run from her. Your mother's the opposite of flat anyhow.

![image](https://github.com/user-attachments/assets/09673956-7720-4728-976c-2a23d5c36502)

Either fix or qol though I'm guessing fix

## Why It's Good For The Game

Your mother is now even more realistic

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Your mom now correctly turns around when running after her disappointment of a child
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
