### PR TITLE
[TG Mirror] Literally just slows the Paddy down by 2.5x [MDB IGNORE]

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -96,6 +96,9 @@
 	name = "\improper APLU \"Paddy\""
 	icon_state = "paddy"
 	base_icon_state = "paddy"
+	movedelay = 5
+	slow_pressure_step_in = 5
+	fast_pressure_step_in = 3
 	max_temperature = 20000
 	max_integrity = 250
 	mech_type = EXOSUIT_MODULE_PADDY


### PR DESCRIPTION
Original PR: 91463
-----
## About The Pull Request

Paddy slow_pressure_step_in from 2 -> 5
Paddy fast_pressure_step_in from 1.5 -> 3

This makes them decently slower than a human, unless they can tag them with disabler shots first.

## Why It's Good For The Game

I think It's deeply, deeply unhealthy that we give security a tool at round start that's faster and more oppressive than a security officer. 

Antagonists essentially have to plan their entire round around the fact that they will be run down the moment they pop their head out. 

It's incredibly punishing to antags that try to focus on stealth, because you generally won't have the tools to combat it, and running is not an option. If your plan falls through, it's over

It's incredibly punishing to antags that don't have access to an EMP, because it outpaces you if you fight, and it outpaces you if you flight. If you get tagged, it's over

It's even punishing to antags that DO have an emp or a mech counter - a traitor has to dedicate 5% of their TC on buying an EMP implant, a wizard will have to dedicate 20% of their spell points to disable tech, a heretic isn't allowed to pick anything but rust

And if you don't want to buy an EMP, well, we made EMPs harder to make a few years back in #73081

TL;DR this thing's speed makes it too oppressive as a roundstart tool, forcing all antags to play around it, and it's not very fun. Slowing it down aims to refocus it from "a tool which is capable of running down literally every antag, including Dragons and Xenos" to "a tool security can use to lock down an area, such as during a riot"

(Yes other mechas are faster, but they're not available roundstart and robotics is useless half the time, so they're considerably less problematic)

## Changelog

:cl: Melbert
balance: Paddy is 2.5x slower
/:cl:
